### PR TITLE
Update sony_bravia_psk.py

### DIFF
--- a/braviapsk/sony_bravia_psk.py
+++ b/braviapsk/sony_bravia_psk.py
@@ -109,7 +109,7 @@ class BraviaRC(object):
         else:
             return True
 
-    def _wakeonlan(self):
+    def _wakeonlan(self,broadcast = "255.255.255.255"):
         if self._mac is not None:
             addr_byte = self._mac.split(':')
             hw_addr = struct.pack('BBBBBB', int(addr_byte[0], 16),
@@ -121,7 +121,7 @@ class BraviaRC(object):
             msg = b'\xff' * 6 + hw_addr * 16
             socket_instance = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             socket_instance.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
-            socket_instance.sendto(msg, ('<broadcast>', 9))
+            socket_instance.sendto(msg, (broadcast, 9))
             socket_instance.close()
 
     def send_req_ircc(self, params, log_errors=True):


### PR DESCRIPTION
Does not work if running on a machine with multiple interfaces i.e.

eth0: 10.1.1.10
eth1: 10.1.2.10

say the braviatv is on subnet 10.1.1.0 , the broadcast address should be set to:

10.1.1.255 the <broadcast> is translated to 255.255.255.255 hence the magic packets are possibly send out to the wrong subnet, depending on the network configuration.

